### PR TITLE
Bugfixes for CI compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cmake"]
 	path = cmake
-	url = git@github.com:lpetre-ulb/gembuild.git
+	url = https://gitlab.cern.ch/lpetre/gembuild.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ function(use_cxx11)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11" PARENT_SCOPE)
     endif()
   else()
-    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD 11 PARENT_SCOPE)
   endif()
 endfunction(use_cxx11)
 

--- a/gembase/CMakeLists.txt
+++ b/gembase/CMakeLists.txt
@@ -2,9 +2,8 @@
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/htdocs)
 file(GLOB htdocs_subdirs
      LIST_DIRECTORIES TRUE
+     RELATIVE ${xDAQ_HTML_DIR}
      CONFIGURE_DEPENDS
-     RELATIVE
-     ${xDAQ_HTML_DIR}
      ${xDAQ_HTML_DIR}/*)
 foreach(subdir IN LISTS htdocs_subdirs)
     add_custom_target(


### PR DESCRIPTION
This PR fixes a few issues impacting the potential success of CI :

* The ssh scheme for submodules does not work for modules outside GitLab. The solution is to move to https by default.
* For newer version of CMake (3.2 and superior), `CMAKE_CXX_STANDARD` is not propagated to the parent scope.
* It appears that the order of parameters is important in `file(GLOB ...)` in older versions of CMake (3.13.4 on CC7).